### PR TITLE
refactor: remove unused scroll restoration function from BrowserRouter

### DIFF
--- a/lib/components/BrowserRouter.tsx
+++ b/lib/components/BrowserRouter.tsx
@@ -1,9 +1,6 @@
 import { useOnce } from "../hooks/useOnce";
 import { BrowserRouterProps } from "../types";
-import {
-  disableBrowserScrollRestoration,
-  initializeBrowserHistory,
-} from "./BrowserRouter.helper";
+import { initializeBrowserHistory } from "./BrowserRouter.helper";
 import { EventListener } from "./EventListener";
 import { Provider } from "./Provider";
 import { Router } from "./Router";
@@ -11,7 +8,6 @@ import { Router } from "./Router";
 export const BrowserRouter = ({ config, ...props }: BrowserRouterProps) => {
   useOnce(() => {
     initializeBrowserHistory();
-    disableBrowserScrollRestoration();
   });
   return (
     <Provider config={config}>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export { BrowserRouter } from "./components/BrowserRouter";
+export { disableBrowserScrollRestoration } from "./components/BrowserRouter.helper";
 export { Link } from "./components/Link";
 export { useRouter } from "./hooks/useRouter";


### PR DESCRIPTION
This pull request includes changes to the `BrowserRouter` component and the main index file to improve code organization and functionality. The most important changes are:

Codebase simplification:

* [`lib/components/BrowserRouter.tsx`](diffhunk://#diff-a70162e64f28747da814d17905a4ca060ab54df68771518ea7eea81d7a3e231aL3-L14): Removed the `disableBrowserScrollRestoration` function call from the `BrowserRouter` component to streamline the initialization process.

Code organization:

* [`lib/index.ts`](diffhunk://#diff-d5a4b3a0309f2337144861084c1014523cced561eb722cb9684c63f5e41e0567R2): Exported the `disableBrowserScrollRestoration` function from the `BrowserRouter.helper` file to make it available for use in other parts of the codebase.