### PR TITLE
13 getparams matchdynamicroute export

### DIFF
--- a/lib/hooks/useCreateSingletonRouter.ts
+++ b/lib/hooks/useCreateSingletonRouter.ts
@@ -3,7 +3,7 @@ import { useContext } from "react";
 import { configContext } from "../contexts/config";
 import { historyContext, setHistoryContext } from "../contexts/history";
 import { History, Router } from "../types";
-import { make } from "../utils";
+import { getParams, make } from "../utils";
 
 export const useCreateSingletonRouter = (path: string | undefined): Router => {
   const history = useContext(historyContext);
@@ -44,25 +44,12 @@ export const useCreateSingletonRouter = (path: string | undefined): Router => {
       apply();
     }
   };
-  const getParams = () => {
-    const pathParams = path
-      ?.split("/")
-      .map((path, index) => [path, index] as const)
-      .filter(([path]) => path.startsWith(":"));
-    const pathnames = history.pathname.split("/");
-    return {
-      ...history.query,
-      ...Object.fromEntries(
-        pathParams?.map(([path, index]) => [path, pathnames[index]]) ?? [],
-      ),
-    };
-  };
 
   return {
     path,
     push,
     replace,
     pathname: history.pathname,
-    params: getParams(),
+    params: getParams(history, path),
   };
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 export { BrowserRouter } from "./components/BrowserRouter";
 export { disableBrowserScrollRestoration } from "./components/BrowserRouter.helper";
 export { Link } from "./components/Link";
+export { matchDynamicRoute } from "./components/Router.helper";
 export { useRouter } from "./hooks/useRouter";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,3 +3,4 @@ export { disableBrowserScrollRestoration } from "./components/BrowserRouter.help
 export { Link } from "./components/Link";
 export { matchDynamicRoute } from "./components/Router.helper";
 export { useRouter } from "./hooks/useRouter";
+export { getParams } from "./utils";

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -13,3 +13,17 @@ export const make = (
     type,
   };
 };
+
+export const getParams = (history: History, path: string | undefined) => {
+  const pathParams = path
+    ?.split("/")
+    .map((path, index) => [path, index] as const)
+    .filter(([path]) => path.startsWith(":"));
+  const pathnames = history.pathname.split("/");
+  return {
+    ...history.query,
+    ...Object.fromEntries(
+      pathParams?.map(([path, index]) => [path, pathnames[index]]) ?? [],
+    ),
+  };
+};


### PR DESCRIPTION
This pull request refactors the `getParams` function to improve code reusability and updates its usage across the codebase. It also adds new exports to the library's public API. Below are the most important changes:

### Refactoring and Code Reusability:
* Moved the `getParams` function from `useCreateSingletonRouter` to `lib/utils.ts` to make it a reusable utility function.
* Updated the `useCreateSingletonRouter` hook to use the newly centralized `getParams` function by passing `history` and `path` as arguments.

### Public API Enhancements:
* Added `getParams` and `matchDynamicRoute` to the public API by exporting them in `lib/index.ts`.

### Dependency Updates:
* Updated the imports in `useCreateSingletonRouter` to include `getParams` from `lib/utils.ts`.